### PR TITLE
samplers: improved DRY performance

### DIFF
--- a/aphrodite/common/sampling_params.py
+++ b/aphrodite/common/sampling_params.py
@@ -228,6 +228,10 @@ class SamplingParams(
             Defaults to None.
         dry_range: The range of tokens (input + output) to apply the DRY
             sampler.
+        dry_max_ngram: Maximum length of match to check.
+        dry_max_occurrences: How many occurrences of last_token we analyze.
+        dry_early_exit_match_len: If we find this large a match, we stop
+            searching.
         skew: Bias the token selection towards higher or lower probability
             tokens. Defaults to 0 (disabled).
         sampler_priority: A list of integers to control the order in which
@@ -284,6 +288,9 @@ class SamplingParams(
     dry_allowed_length: int = 2
     dry_sequence_breaker_ids: List[int] = []
     dry_range: int = 0
+    dry_max_ngram: int = 12
+    dry_max_occurrences: int = 8
+    dry_early_exit_match_len: int = 8
     skew: float = 0.0
     sampler_priority: Optional[List[int]] = []
     output_kind: RequestOutputKind = RequestOutputKind.CUMULATIVE
@@ -339,6 +346,9 @@ class SamplingParams(
         "dry_allowed_length": 2,
         "dry_sequence_breaker_ids": [],
         "dry_range": 0,
+        "dry_max_ngram": 12,
+        "dry_max_occurrences": 8,
+        "dry_early_exit_match_len": 8,
         "skew": 0.0,
         "sampler_priority": [],
         "output_kind": RequestOutputKind.CUMULATIVE,
@@ -496,6 +506,18 @@ class SamplingParams(
             raise ValueError(
                 "dry_range must be non-negative, got "
                 f"{self.dry_range}.")
+        if self.dry_max_ngram < 0:
+            raise ValueError(
+                "dry_max_ngram must be non-negative, got "
+                f"{self.dry_max_ngram}.")
+        if self.dry_max_occurrences < 0:
+            raise ValueError(
+                "dry_max_occurrences must be non-negative, got "
+                f"{self.dry_max_occurrences}.")
+        if self.dry_early_exit_match_len < 0:
+            raise ValueError(
+                "dry_early_exit_match_len must be non-negative, got "
+                f"{self.dry_early_exit_match_len}.")
         if self.skew < 0.0:
             raise ValueError(
                 "skew must be non-negative, got "

--- a/aphrodite/endpoints/openai/protocol.py
+++ b/aphrodite/endpoints/openai/protocol.py
@@ -188,6 +188,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
         default=0,
         validation_alias=AliasChoices("dry_range",
                                       "dry_penalty_last_n"))
+    dry_max_ngram: Optional[int] = 12
+    dry_max_occurrences: Optional[int] = 8
+    dry_early_exit_match_len: Optional[int] = 8
     dynatemp_min: Optional[float] = 0.0
     dynatemp_max: Optional[float] = 0.0
     dynatemp_exponent: Optional[float] = 1.0
@@ -350,6 +353,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
             dry_allowed_length=self.dry_allowed_length,
             dry_sequence_breaker_ids=dry_sequence_breaker_ids,
             dry_range=self.dry_range,
+            dry_max_ngram=self.dry_max_ngram,
+            dry_max_occurrences=self.dry_max_occurrences,
+            dry_early_exit_match_len=self.dry_early_exit_match_len,
             dynatemp_min=self.dynatemp_min,
             dynatemp_max=self.dynatemp_max,
             dynatemp_exponent=self.dynatemp_exponent,
@@ -513,6 +519,9 @@ class CompletionRequest(OpenAIBaseModel):
         default=0,
         validation_alias=AliasChoices("dry_range",
                                       "dry_penalty_last_n"))
+    dry_max_ngram: Optional[int] = 12
+    dry_max_occurrences: Optional[int] = 8
+    dry_early_exit_match_len: Optional[int] = 8
     dynatemp_min: Optional[float] = 0.0
     dynatemp_max: Optional[float] = 0.0
     dynatemp_exponent: Optional[float] = 1.0
@@ -634,6 +643,9 @@ class CompletionRequest(OpenAIBaseModel):
             dry_allowed_length=self.dry_allowed_length,
             dry_sequence_breaker_ids=dry_sequence_breaker_ids,
             dry_range=self.dry_range,
+            dry_max_ngram=self.dry_max_ngram,
+            dry_max_occurrences=self.dry_max_occurrences,
+            dry_early_exit_match_len=self.dry_early_exit_match_len,
             dynatemp_min=self.dynatemp_min,
             dynatemp_max=self.dynatemp_max,
             dynatemp_exponent=self.dynatemp_exponent,

--- a/aphrodite/modeling/sampling_metadata.py
+++ b/aphrodite/modeling/sampling_metadata.py
@@ -385,6 +385,9 @@ class SamplingTensors:
     dry_allowed_lengths: torch.Tensor
     dry_sequence_breaker_ids: torch.Tensor
     dry_ranges: torch.Tensor
+    dry_max_ngram: torch.Tensor
+    dry_max_occurrences: torch.Tensor
+    dry_early_exit_match_len: torch.Tensor
     skews: torch.Tensor
     prompt_tokens: torch.Tensor
     output_tokens: torch.Tensor
@@ -427,6 +430,9 @@ class SamplingTensors:
         dry_allowed_lengths: List[int] = []
         dry_sequence_breaker_ids: List[List[int]] = []
         dry_ranges: List[int] = []
+        dry_max_ngram: List[int] = []
+        dry_max_occurrences: List[int] = []
+        dry_early_exit_match_len: List[int] = []
         skews: List[float] = []
 
         do_penalties = False
@@ -525,6 +531,10 @@ class SamplingTensors:
             dry_sequence_breaker_ids += (
                 [params.dry_sequence_breaker_ids] * n_seqs)
             dry_ranges += [params.dry_range] * n_seqs
+            dry_max_ngram += [params.dry_max_ngram] * n_seqs
+            dry_max_occurrences += [params.dry_max_occurrences] * n_seqs
+            dry_early_exit_match_len += [
+                params.dry_early_exit_match_len] * n_seqs
             skews += [params.skew] * n_seqs
 
         if do_penalties or do_dry or do_no_repeat_ngrams:
@@ -573,6 +583,9 @@ class SamplingTensors:
             dry_allowed_lengths,
             dry_sequence_breaker_ids,
             dry_ranges,
+            dry_max_ngram,
+            dry_max_occurrences,
+            dry_early_exit_match_len,
             skews,
             prompt_tokens,
             output_tokens,
@@ -628,6 +641,9 @@ class SamplingTensors:
         dry_allowed_lengths: List[int],
         dry_sequence_breaker_ids: List[List[int]],
         dry_ranges: List[int],
+        dry_max_ngram: List[int],
+        dry_max_occurrences: List[int],
+        dry_early_exit_match_len: List[int],
         skews: List[float],
         prompt_tokens: List[array],
         output_tokens: List[array],
@@ -803,6 +819,24 @@ class SamplingTensors:
             dtype=torch.int,
             pin_memory=pin_memory,
         )
+        dry_max_ngram_t = torch.tensor(
+            dry_max_ngram,
+            device="cpu",
+            dtype=torch.int,
+            pin_memory=pin_memory,
+        )
+        dry_max_occurrences_t = torch.tensor(
+            dry_max_occurrences,
+            device="cpu",
+            dtype=torch.int,
+            pin_memory=pin_memory,
+        )
+        dry_early_exit_match_len_t = torch.tensor(
+            dry_early_exit_match_len,
+            device="cpu",
+            dtype=torch.int,
+            pin_memory=pin_memory,
+        )
         skews_t = torch.tensor(
             skews,
             device="cpu",
@@ -852,6 +886,11 @@ class SamplingTensors:
             dry_sequence_breaker_ids=dry_sequence_breakers_t.to(device=device,
                                                                 non_blocking=True),
             dry_ranges=dry_ranges_t.to(device=device, non_blocking=True),
+            dry_max_ngram=dry_max_ngram_t.to(device=device, non_blocking=True),
+            dry_max_occurrences=dry_max_occurrences_t.to(device=device,
+                                                         non_blocking=True),
+            dry_early_exit_match_len=dry_early_exit_match_len_t.to(
+                device=device, non_blocking=True),
             skews=skews_t.to(device=device, non_blocking=True),
             typical_ps=typical_ps_t.to(device=device, non_blocking=True),
             prompt_tokens=prompt_t.to(device=device, non_blocking=True),


### PR DESCRIPTION
PR:
```
Starting: Batch 1 (20 requests without dry_multiplier)
Batch 1 (20 requests without dry_multiplier): Completed 20 requests in 14.64 seconds
Starting: Batch 2 (10/20 requests with dry_multiplier)
Batch 2 (10/20 requests with dry_multiplier): Completed 20 requests in 19.11 seconds
Starting: Batch 3 (20 requests with dry_multiplier)
Batch 3 (20 requests with dry_multiplier): Completed 20 requests in 23.49 seconds
Total execution time for all batches: 57.24 seconds
```

Main:
```
Starting: Batch 1 (20 requests without dry_multiplier)
Batch 1 (20 requests without dry_multiplier): Completed 20 requests in 14.69 seconds
Starting: Batch 2 (10/20 requests with dry_multiplier)
Batch 2 (10/20 requests with dry_multiplier): Completed 20 requests in 26.89 seconds
Starting: Batch 3 (20 requests with dry_multiplier)
Batch 3 (20 requests with dry_multiplier): Completed 20 requests in 37.49 seconds
Total execution time for all batches: 79.07 seconds
```