### PR TITLE
API: use heartbeats instead of health checks

### DIFF
--- a/aphrodite/common/envs.py
+++ b/aphrodite/common/envs.py
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
     APHRODITE_DYNAMIC_ROPE_SCALING: bool = False
     APHRODITE_TEST_FORCE_FP8_MARLIN: bool = False
     APHRODITE_PLUGINS: Optional[List[str]] = None
-    APHRODITE_RPC_TIMEOUT: int = 5000
+    APHRODITE_RPC_TIMEOUT: int = 20000
     APHRODITE_FORCE_SINGLE_USER_PREFIX_CACHE: bool = False
     APHRODITE_TEST_DYNAMO_GRAPH_CAPTURE: int = 0
     APHRODITE_TEST_DYNAMO_FULLGRAPH_CAPTURE: int = 0
@@ -385,7 +385,7 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # Time in ms for the zmq client to wait for a response from the backend
     # server for simple data operations
     "APHRODITE_RPC_TIMEOUT":
-    lambda: int(os.getenv("APHRODITE_RPC_TIMEOUT", "5000")),
+    lambda: int(os.getenv("APHRODITE_RPC_TIMEOUT", "20000")),
 
     # a list of plugin names to load, separated by commas.
     # if this is not set, it means all plugins will be loaded

--- a/aphrodite/engine/multiprocessing/__init__.py
+++ b/aphrodite/engine/multiprocessing/__init__.py
@@ -43,9 +43,6 @@ class RPCAbortRequest:
     request_id: str
 
 
-class RPCHealthRequest:
-    pass
-
 
 class RPCStartupRequest(Enum):
     IS_SERVER_READY = 1
@@ -61,13 +58,7 @@ class RPCShutdownRequest:
     pass
 
 
-RPC_REQUEST_T = Union[
-    RPCProcessRequest,
-    RPCAbortRequest,
-    RPCHealthRequest,
-    RPCStartupRequest,
-    RPCShutdownRequest,
-]
+RPC_REQUEST_T = Union[RPCProcessRequest, RPCAbortRequest, RPCStartupRequest]
 
 REQUEST_OUTPUTS_T = Union[List[RequestOutput], RPCError]
 

--- a/tests/mq_aphrodite_engine/test_error_handling.py
+++ b/tests/mq_aphrodite_engine/test_error_handling.py
@@ -149,26 +149,19 @@ async def test_failed_abort(tmp_socket):
         await client.check_health()
 
         # Trigger an abort on the client side.
-        async def bad_abort_after_2s():
-            await asyncio.sleep(2.0)
-            await client.abort(request_id="foo")
+        # This request ID does not exist, and will cause the engine to error
+        await client.abort(request_id="foo")
 
-        # Trigger an abort in 2s from now.
-        abort_task = asyncio.create_task(bad_abort_after_2s())
-
-        # Exception in abort() will happen during this generation.
-        # This will kill the engine and should return ENGINE_DEAD_ERROR
+        # Future generation requests will now fail
         # with reference to the original KeyError("foo")
         with pytest.raises(MQEngineDeadError) as execinfo:
             async for _ in client.generate(
                     prompt="Hello my name is",
-                    sampling_params=SamplingParams(max_tokens=2000),
+                    sampling_params=SamplingParams(max_tokens=10),
                     request_id=uuid.uuid4()):
                 pass
         assert "KeyError" in repr(execinfo.value)
         assert client.errored
-
-        await abort_task
 
         # This should raise the original error.
         with pytest.raises(RAISED_ERROR):


### PR DESCRIPTION
The heartbeat runs on a separate thread so it's not queued behind other requests.