### PR TITLE
api: expose priority scheduling in the API server

### DIFF
--- a/aphrodite/endpoints/openai/protocol.py
+++ b/aphrodite/endpoints/openai/protocol.py
@@ -298,6 +298,12 @@ class ChatCompletionRequest(OpenAIBaseModel):
         description=(
             "If specified, will override the default whitespace pattern "
             "for guided json decoding."))
+    priority: int = Field(
+        default=0,
+        description=(
+            "The priority of the request (lower means earlier handling; "
+            "default: 0). Any priority other than 0 will raise an error "
+            "if the served model does not use priority scheduling."))
 
     # doc: end-chat-completion-extra-params
 
@@ -595,6 +601,12 @@ class CompletionRequest(OpenAIBaseModel):
         description=(
             "If specified, will override the default whitespace pattern "
             "for guided json decoding."))
+    priority: int = Field(
+        default=0,
+        description=(
+            "The priority of the request (lower means earlier handling; "
+            "default: 0). Any priority other than 0 will raise an error "
+            "if the served model does not use priority scheduling."))
 
     # doc: end-completion-extra-params
 
@@ -751,6 +763,15 @@ class EmbeddingRequest(OpenAIBaseModel):
     additional_data: Optional[Any] = None
 
     # doc: end-embedding-pooling-params
+
+    # doc: begin-embedding-extra-params
+    priority: int = Field(
+        default=0,
+        description=(
+            "The priority of the request (lower means earlier handling; "
+            "default: 0). Any priority other than 0 will raise an error "
+            "if the served model does not use priority scheduling."))
+    # doc: end-embedding-extra-params
 
     def to_pooling_params(self):
         return PoolingParams(additional_data=self.additional_data)

--- a/aphrodite/endpoints/openai/serving_chat.py
+++ b/aphrodite/endpoints/openai/serving_chat.py
@@ -225,6 +225,7 @@ class OpenAIServingChat(OpenAIServing):
                 request_id,
                 lora_request=lora_request,
                 prompt_adapter_request=prompt_adapter_request,
+                priority=request.priority,
             )
         except ValueError as e:
             # TODO: Use an aphrodite-specific Validation Error

--- a/aphrodite/endpoints/openai/serving_completions.py
+++ b/aphrodite/endpoints/openai/serving_completions.py
@@ -129,6 +129,7 @@ class OpenAIServingCompletion(OpenAIServing):
                     request_id_item,
                     lora_request=lora_request,
                     prompt_adapter_request=prompt_adapter_request,
+                    priority=request.priority,
                 )
 
                 generators.append(generator)

--- a/aphrodite/endpoints/openai/serving_embedding.py
+++ b/aphrodite/endpoints/openai/serving_embedding.py
@@ -136,6 +136,7 @@ class OpenAIServingEmbedding(OpenAIServing):
                     pooling_params,
                     request_id_item,
                     lora_request=lora_request,
+                    priority=request.priority,
                 )
 
                 generators.append(generator)

--- a/aphrodite/engine/async_aphrodite.py
+++ b/aphrodite/engine/async_aphrodite.py
@@ -902,6 +902,7 @@ class AsyncAphrodite:
         pooling_params: PoolingParams,
         request_id: str,
         lora_request: Optional[LoRARequest] = None,
+        priority: int = 0,
     ) -> AsyncGenerator[EmbeddingRequestOutput, None]:
         """Generate outputs for a request from an embedding model.
 
@@ -916,6 +917,8 @@ class AsyncAphrodite:
             pooling_params: The pooling parameters of the request.
             request_id: The unique id of the request.
             lora_request: LoRA request to use for generation, if any.
+            priority: The priority of the request.
+                Only applicable with priority scheduling.
 
         Yields:
             The output `EmbeddingRequestOutput` objects from the AphroditeEngine
@@ -967,6 +970,7 @@ class AsyncAphrodite:
                 prompt,
                 pooling_params,
                 lora_request=lora_request,
+                priority=priority,
         ):
             yield AphroditeEngine.validate_output(output,
                                                   EmbeddingRequestOutput)

--- a/aphrodite/engine/multiprocessing/__init__.py
+++ b/aphrodite/engine/multiprocessing/__init__.py
@@ -29,6 +29,7 @@ class RPCProcessRequest:
     lora_request: Optional[LoRARequest] = None
     trace_headers: Optional[Mapping[str, str]] = None
     prompt_adapter_request: Optional[PromptAdapterRequest] = None
+    priority: int = 0
 
 
 @dataclass

--- a/aphrodite/engine/protocol.py
+++ b/aphrodite/engine/protocol.py
@@ -39,7 +39,8 @@ class EngineClient(Protocol):
         sampling_params: SamplingParams,
         request_id: str,
         lora_request: Optional[LoRARequest] = None,
-        prompt_adapter_request: Optional[PromptAdapterRequest] = None
+        prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        priority: int = 0,
     ) -> AsyncGenerator[RequestOutput, None]:
         """Generates outputs for a request"""
         ...
@@ -50,6 +51,7 @@ class EngineClient(Protocol):
         pooling_params: PoolingParams,
         request_id: str,
         lora_request: Optional[LoRARequest] = None,
+        priority: int = 0,
     ) -> AsyncGenerator[EmbeddingRequestOutput, None]:
         """Generate outputs for a request from an embedding model."""
         ...

--- a/tests/benchmarks/engine/prioritization.py
+++ b/tests/benchmarks/engine/prioritization.py
@@ -102,6 +102,7 @@ def run_aphrodite(
         enable_chunked_prefill=enable_chunked_prefill,
         max_num_batched_tokens=max_num_batched_tokens,
         disable_log_stats=False,
+        scheduling_policy="priority",
     )
 
     # Add the requests to the engine.


### PR DESCRIPTION
If `--scheduling-policy priority` is set at launch, requests containing a `priority` parameter with a value larger than 0 (default) will be prioritized. 1 means the highest priority, and ascending numbers will have a lower priority in the queue. Requests with 0 (default) will be treated in a FIFO (first-in first-out) fashion.