### PR TITLE
feat: add request-level logging

### DIFF
--- a/aphrodite/common/envs.py
+++ b/aphrodite/common/envs.py
@@ -63,6 +63,7 @@ if TYPE_CHECKING:
     APHRODITE_USE_TRITON_BACKEND: bool = False
     APHRODITE_FORCE_P2P: bool = False
     APHRODITE_TEST_ENABLE_ARTIFICIAL_PREEMPT: bool = False
+    APHRODITE_REQUEST_LEVEL_METRICS: bool = False
 
 
 def get_default_cache_root():
@@ -418,6 +419,11 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     "APHRODITE_TEST_ENABLE_ARTIFICIAL_PREEMPT":
     lambda: bool(int(
         os.getenv("APHRODITE_TEST_ENABLE_ARTIFICIAL_PREEMPT", "0"))),
+
+    # If set, Aphrodite will use request-level metrics instead of
+    # interval-based metrics.
+    "APHRODITE_REQUEST_LEVEL_METRICS":
+    lambda: bool(int(os.getenv("APHRODITE_REQUEST_LEVEL_METRICS", "0"))),
 }
 
 # end-env-vars-definition

--- a/aphrodite/engine/metrics_types.py
+++ b/aphrodite/engine/metrics_types.py
@@ -13,6 +13,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Protocol
 
+import aphrodite.common.envs as envs
 from aphrodite.spec_decode.metrics import SpecDecodeWorkerMetrics
 
 
@@ -46,17 +47,24 @@ class Stats:
     best_of_requests: List[int]
     n_requests: List[int]
     finished_reason_requests: List[str]
+    request_ids: List[str]
     spec_decode_metrics: Optional["SpecDecodeWorkerMetrics"] = None
+
+
 class SupportsMetricsInfo(Protocol):
     def metrics_info(self) -> Dict[str, str]:
         ...
+
+
 class StatLoggerBase(ABC):
     """Base class for StatLogger."""
     def __init__(self, local_interval: float) -> None:
-        # Tracked stats over current local logging interval.
-        self.num_prompt_tokens: List[int] = []
-        self.num_generation_tokens: List[int] = []
-        self.last_local_log = time.time()
+        self.request_level_metrics = envs.APHRODITE_REQUEST_LEVEL_METRICS
+        # Only initialize these if not using request-level metrics
+        if not self.request_level_metrics:
+            self.num_prompt_tokens: List[int] = []
+            self.num_generation_tokens: List[int] = []
+            self.last_local_log = time.time()
         self.local_interval = local_interval
         self.spec_decode_metrics: Optional["SpecDecodeWorkerMetrics"] = None
     @abstractmethod

--- a/aphrodite/engine/multiprocessing/client.py
+++ b/aphrodite/engine/multiprocessing/client.py
@@ -386,8 +386,8 @@ class MQAphroditeEngineClient:
             lora_request: LoRA request to use for generation, if any.
             prompt_adapter_request: Prompt Adapter request to use
                                             for generation, if any.
-            priority: Priority of the request (lower means earlier handling). 
-                Any priority other than 0 will lead to an error if the 
+            priority: Priority of the request (lower means earlier handling).
+                Any priority other than 0 will lead to an error if the
                 scheduling policy is not "priority".
         """
         return self._process_request(prompt, sampling_params, request_id,


### PR DESCRIPTION
By exporting `APHRODITE_REQUEST_LEVEL_METRICS=1`, the engine will log metrics on a per-request basis, instead of interval-based.

![image](https://github.com/user-attachments/assets/0fa11726-f267-4a99-a926-424d7b86fc5e)
