### PR TITLE
core: make v2 block manager the default

### DIFF
--- a/aphrodite/common/config.py
+++ b/aphrodite/common/config.py
@@ -1134,7 +1134,7 @@ class SchedulerConfig:
                  max_model_len: int,
                  cache_config: Optional["CacheConfig"] = None,
                  is_attention_free: bool = False,
-                 use_v2_block_manager: bool = False,
+                 use_v2_block_manager: bool = True,
                  num_lookahead_slots: int = 0,
                  delay_factor: float = 0.0,
                  enable_chunked_prefill: bool = False,

--- a/aphrodite/engine/args_tools.py
+++ b/aphrodite/engine/args_tools.py
@@ -122,7 +122,7 @@ class EngineArgs:
     swap_space: float = 4  # GiB
     cpu_offload_gb: float = 0  # GiB
     # Scheduler Options
-    use_v2_block_manager: bool = False
+    use_v2_block_manager: bool = True
     scheduler_delay_factor: float = 0.0
     enable_chunked_prefill: Optional[bool] = None
     guided_decoding_backend: str = 'lm-format-enforcer'
@@ -615,10 +615,12 @@ class EngineArgs:
             'loaded from CPU memory to GPU memory on the fly in each '
             'model forward pass.')
         # Scheduler Options
-        parser.add_argument("--use-v2-block-manager",
-                            action="store_true",
-                            help="Category: Scheduler Options\n"
-                            "Use the v2 block manager.")
+        parser.add_argument(
+            '--use-v2-block-manager',
+            default=EngineArgs.use_v2_block_manager,
+            action='store_true',
+            help='Use BlockSpaceMangerV2. By default this is set to True. '
+            'Set to False to use BlockSpaceManagerV1')
         parser.add_argument(
             "--scheduler-delay-factor",
             "-sdf",

--- a/aphrodite/processing/interfaces.py
+++ b/aphrodite/processing/interfaces.py
@@ -4,6 +4,8 @@ from typing import List
 from typing import Sequence as GenericSequence
 from typing import Tuple
 
+from loguru import logger
+
 from aphrodite.common.sequence import Sequence, SequenceGroup
 from aphrodite.common.utils import Device
 
@@ -31,11 +33,13 @@ class BlockSpaceManager(ABC):
         if version == "v1":
             from aphrodite.processing.block_manager_v1 import (
                 BlockSpaceManagerV1)
+            logger.info("Using v1 BlockSpaceManager")
             return BlockSpaceManagerV1
 
         if version == "v2":
             from aphrodite.processing.block_manager_v2 import (
                 BlockSpaceManagerV2)
+            logger.info("Using v2 BlockSpaceManager")
             return BlockSpaceManagerV2
 
         if version == "placeholder":


### PR DESCRIPTION
V1 will be deprecated soon. If users want to use V1 still, they can set `--use-v2-block-manager=False`.