### PR TITLE
sampler: add option to ban tokens within a specific range of output tokens

### DIFF
--- a/aphrodite/common/sampling_params.py
+++ b/aphrodite/common/sampling_params.py
@@ -3,7 +3,7 @@ import copy
 from dataclasses import dataclass
 from enum import Enum, IntEnum
 from functools import cached_property
-from typing import Any, Callable, Dict, List, Optional, Set, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 import msgspec
 import torch
@@ -250,6 +250,8 @@ class SamplingParams(
         prompt_logprobs: Number of log probabilities to return per prompt token.
         detokenize: Whether to detokenize the output. Defaults to True.
         custom_token_bans: List of token IDs to ban from generating
+        token_ban_ranges: List of tuples (tokens, start, length) to ban from
+            generating. start=0 means start from first output token.
         skip_special_tokens: Whether to skip special tokens in the output.
             defaults to true.
         spaces_between_special_tokens: Whether to add spaces between special
@@ -340,6 +342,7 @@ class SamplingParams(
     prompt_logprobs: Optional[int] = None
     detokenize: bool = True
     custom_token_bans: Optional[List[int]] = None
+    token_ban_ranges: Optional[List[Tuple[List[int], int, int]]] = None
     skip_special_tokens: bool = True
     spaces_between_special_tokens: bool = True
     # Optional[List[LogitsProcessorFunc]] type.
@@ -406,6 +409,7 @@ class SamplingParams(
         "prompt_logprobs": None,
         "detokenize": True,
         "custom_token_bans": None,
+        "token_ban_ranges": None,
         "skip_special_tokens": True,
         "spaces_between_special_tokens": True,
         "include_stop_str_in_output": False,
@@ -604,6 +608,14 @@ class SamplingParams(
             raise ValueError(
                 "skew must be non-negative, got "
                 f"{self.skew}.")
+        if self.custom_token_bans is not None and not isinstance(
+            self.custom_token_bans, list):
+            raise ValueError(
+                "custom_token_bans must be a list of integers")
+        if self.token_ban_ranges is not None and not isinstance(
+            self.token_ban_ranges, list):
+            raise ValueError(
+                "token_ban_ranges must be a list of tuples")
 
         if self.sampler_priority is not None:
             if not self.sampler_priority:

--- a/aphrodite/endpoints/openai/protocol.py
+++ b/aphrodite/endpoints/openai/protocol.py
@@ -2,7 +2,7 @@
 # https://github.com/lm-sys/FastChat/blob/168ccc29d3f7edc50823016105c024fe2282732a/fastchat/protocol/openai_api_protocol.py
 import json
 import time
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import torch
 from openai.types.chat import ChatCompletionContentPartParam
@@ -201,6 +201,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     nsigma: Optional[float] = 0.0
     skew: Optional[float] = 0.0
     custom_token_bans: Optional[List[int]] = None
+    token_ban_ranges: Optional[List[Tuple[List[int], int, int]]] = None
     sampler_priority: Optional[Union[List[int], List[str]]] = Field(
         default=[],
         validation_alias=AliasChoices("sampler_priority",
@@ -386,6 +387,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             nsigma=self.nsigma,
             skew=self.skew,
             custom_token_bans=self.custom_token_bans,
+            token_ban_ranges=self.token_ban_ranges,
             sampler_priority=self.sampler_priority,
             output_kind=RequestOutputKind.DELTA if self.stream \
                 else RequestOutputKind.FINAL_ONLY,
@@ -578,6 +580,7 @@ class CompletionRequest(OpenAIBaseModel):
     nsigma: Optional[float] = 0.0
     skew: Optional[float] = 0.0
     custom_token_bans: Optional[List[int]] = None
+    token_ban_ranges: Optional[List[Tuple[List[int], int, int]]] = None
     sampler_priority: Optional[Union[List[int], List[str]]] = Field(
         default=[],
         validation_alias=AliasChoices("sampler_priority",
@@ -715,6 +718,7 @@ class CompletionRequest(OpenAIBaseModel):
             nsigma=self.nsigma,
             skew=self.skew,
             custom_token_bans=self.custom_token_bans,
+            token_ban_ranges=self.token_ban_ranges,
             sampler_priority=self.sampler_priority,
             output_kind=RequestOutputKind.DELTA if self.stream \
                 else RequestOutputKind.FINAL_ONLY,


### PR DESCRIPTION
Ban a specific token across a range of output tokens, e.g.:

```sh
    "token_ban_ranges": [
        [[7762, 7763], 0, 10]
    ]
```

This bans tokens 7762 and 7763, starting from the first token (0), all the way to the 10th output token.

The input type is:

```py
token_ban_ranges: List[Tuple[List[int], int, int]]
```

Where the `List[int]` is the list of tokens to ban, the first `int` is the starting position in the output (0=start), and the second `int` is the number of tokens to consider after the starting position.