### PR TITLE
fix: handle older torch versions in fake ops registration

### DIFF
--- a/aphrodite/_custom_ops.py
+++ b/aphrodite/_custom_ops.py
@@ -1,8 +1,9 @@
 import contextlib
 import functools
-from typing import List, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, List, Optional, Tuple, Type, Union
 
 import torch
+import torch.library
 from loguru import logger
 
 import aphrodite.common.envs as envs
@@ -28,6 +29,17 @@ supports_moe_ops = True
 with contextlib.suppress(ImportError):
     # ruff: noqa: F401
     import aphrodite._xqa_C
+
+
+if TYPE_CHECKING:
+
+    def register_fake(fn):
+        return lambda name: fn
+else:
+    try:
+        from torch.library import register_fake
+    except ImportError:
+        from torch.library import impl_abstract as register_fake
 
 
 def hint_on_error(fn):
@@ -288,7 +300,7 @@ def gptq_gemm(a: torch.Tensor, b_q_weight: torch.Tensor,
 # TODO: has to be a better way to do this
 try:
     torch.ops._C.gptq_gemm  # noqa B018
-    @torch.library.register_fake("_C::gptq_gemm")
+    @register_fake("_C::gptq_gemm")
     def _gptq_gemm_fake(a: torch.Tensor, b_q_weight: torch.Tensor,
                         b_gptq_qzeros: torch.Tensor,
                         b_gptq_scales: torch.Tensor, b_g_idx: torch.Tensor,
@@ -332,7 +344,7 @@ def gptq_marlin_24_gemm(a: torch.Tensor, b_q_weight: torch.Tensor,
 # TODO: has to be a better way to do this
 try:
     torch.ops._C.gptq_marlin_24_gemm  # noqa B018
-    @torch.library.register_fake("_C::gptq_marlin_24_gemm")
+    @register_fake("_C::gptq_marlin_24_gemm")
     def _gptq_marlin_24_gemm_fake(a: torch.Tensor, b_q_weight: torch.Tensor,
                                   b_meta: torch.Tensor, b_scales: torch.Tensor,
                                   workspace: torch.Tensor,
@@ -340,7 +352,7 @@ try:
                                   size_n: int, size_k: int) -> torch.Tensor:
         return torch.empty((size_m, size_n), device=a.device, dtype=a.dtype)
 
-    @torch.library.register_fake("_C::gptq_marlin_gemm")
+    @register_fake("_C::gptq_marlin_gemm")
     def _gptq_marlin_gemm_fake(a: torch.Tensor,
                                b_q_weight: torch.Tensor,
                                b_scales: torch.Tensor,
@@ -357,12 +369,12 @@ try:
                                use_fp32_reduce: bool = False) -> torch.Tensor:
         return torch.empty((size_m, size_n), device=a.device, dtype=a.dtype)
 
-    @torch.library.register_fake("_C::ggml_dequantize")
+    @register_fake("_C::ggml_dequantize")
     def _ggml_dequantize_fake(W: torch.Tensor, quant_type: int, m: int,
                               n: int) -> torch.Tensor:
         return torch.empty((m, n), dtype=torch.float16, device=W.device)
 
-    @torch.library.register_fake("_C::ggml_mul_mat_vec_a8")
+    @register_fake("_C::ggml_mul_mat_vec_a8")
     def _ggml_mul_mat_vec_a8_fake(
         W: torch.Tensor,
         X: torch.Tensor,
@@ -371,7 +383,7 @@ try:
     ) -> torch.Tensor:
         return torch.empty((1, row), dtype=torch.float16, device=W.device)
 
-    @torch.library.register_fake("_C::ggml_mul_mat_a8")
+    @register_fake("_C::ggml_mul_mat_a8")
     def _ggml_mul_mat_a8_fake(
         W: torch.Tensor,
         X: torch.Tensor,
@@ -381,7 +393,7 @@ try:
         batch = X.size(0)
         return torch.empty((batch, row), dtype=torch.float16, device=W.device)
 
-    @torch.library.register_fake("_C::marlin_qqq_gemm")
+    @register_fake("_C::marlin_qqq_gemm")
     def _marlin_qqq_gemm_fake(a: torch.Tensor, b_q_weight: torch.Tensor,
                               s_tok: torch.Tensor, s_ch: torch.Tensor,
                               s_group: torch.Tensor, workspace: torch.Tensor,
@@ -391,7 +403,7 @@ try:
                            dtype=torch.float16,
                            device=a.device)
 
-    @torch.library.register_fake("_C::marlin_gemm")
+    @register_fake("_C::marlin_gemm")
     def _marlin_gemm_fake(a: torch.Tensor, b_q_weight: torch.Tensor,
                           b_scales: torch.Tensor, workspace: torch.Tensor,
                           size_m: int, size_n: int,
@@ -400,7 +412,7 @@ try:
                            dtype=torch.float16,
                            device=a.device)
 
-    @torch.library.register_fake("_C::awq_dequantize")
+    @register_fake("_C::awq_dequantize")
     def _awq_dequantize_fake(qweight: torch.Tensor, scales: torch.Tensor,
                              zeros: torch.Tensor, split_k_iters: int, thx: int,
                              thy: int) -> torch.Tensor:
@@ -411,7 +423,7 @@ try:
                            dtype=scales.dtype,
                            device=scales.device)
 
-    @torch.library.register_fake("_C::awq_gemm")
+    @register_fake("_C::awq_gemm")
     def _awq_gemm_fake(input: torch.Tensor, qweight: torch.Tensor,
                        qzeros: torch.Tensor, scales: torch.Tensor,
                        split_k_iters: int) -> torch.Tensor:
@@ -420,7 +432,7 @@ try:
                            dtype=input.dtype,
                            device=input.device).sum(0)
 
-    @torch.library.register_fake("_C::aqlm_gemm")
+    @register_fake("_C::aqlm_gemm")
     def _aqlm_gemm_fake(input: torch.Tensor, codes: torch.Tensor,
                         codebooks: torch.Tensor, scales: torch.Tensor,
                         codebook_partition_sizes: List[int],
@@ -435,7 +447,7 @@ try:
         output_sizes.append(-1)
         return flat_output.reshape(tuple(output_sizes))
 
-    @torch.library.register_fake("_C::aqlm_dequant")
+    @register_fake("_C::aqlm_dequant")
     def _aqlm_dequant_fake(
             codes: torch.Tensor, codebooks: torch.Tensor,
             codebook_partition_sizes: List[int]) -> torch.Tensor:
@@ -445,7 +457,7 @@ try:
                            dtype=codebooks.dtype,
                            device=codebooks.device)
 
-    @torch.library.register_fake("_C::vptq_gemm")
+    @register_fake("_C::vptq_gemm")
     def _vptq_gemm_fake(input: torch.Tensor, indices: torch.Tensor,
                         codebooks: torch.Tensor, weight_scale: torch.Tensor,
                         weight_bias: torch.Tensor, g_i_o: List[int],
@@ -464,7 +476,7 @@ try:
         output_sizes.append(-1)
         return flat_output.reshape(tuple(output_sizes))
 
-    @torch.library.register_fake("_C::vptq_dequant")
+    @register_fake("_C::vptq_dequant")
     def _vptq_dequant_fake(indices: torch.Tensor, codebooks: torch.Tensor,
                            weight_scale: torch.Tensor,
                            weight_bias: torch.Tensor, g_i_o: List[int],
@@ -477,14 +489,14 @@ try:
                            dtype=codebooks.dtype,
                            device=codebooks.device)
 
-    @torch.library.register_fake("_C::fp8_marlin_gemm")
+    @register_fake("_C::fp8_marlin_gemm")
     def _fp8_marlin_gemm_fake(a: torch.Tensor, b_q_weight: torch.Tensor,
                               b_scales: torch.Tensor, workspace: torch.Tensor,
                               num_bits: int, size_m: int, size_n: int,
                               size_k: int) -> torch.Tensor:
         return torch.empty((size_m, size_n), dtype=a.dtype, device=a.device)
 
-    @torch.library.register_fake("_C::machete_gemm")
+    @register_fake("_C::machete_gemm")
     def machete_gemm_fake(
         a: torch.Tensor,
         b_q: torch.Tensor,  # Should be the tensor returned by machete_prepack_B
@@ -501,12 +513,12 @@ try:
         n = b_q.size(1)
         return torch.empty((m, n), device=a.device, dtype=a.dtype)
 
-    @torch.library.register_fake("_C::machete_prepack_B")
+    @register_fake("_C::machete_prepack_B")
     def machete_prepack_B_fake(b_q_weight: torch.Tensor,
                                b_type: ScalarType) -> torch.Tensor:
         return torch.empty_like(b_q_weight)
 
-    @torch.library.register_fake("_C::causal_conv1d_fwd")
+    @register_fake("_C::causal_conv1d_fwd")
     def causal_conv1d_fwd_fake(x: torch.Tensor, weight: torch.Tensor,
                                bias_: Optional[torch.Tensor],
                                conv_states: Optional[torch.Tensor],
@@ -516,7 +528,7 @@ try:
                                silu_activation: bool) -> torch.Tensor:
         return torch.empty_like(x)
 
-    @torch.library.register_fake("_C::causal_conv1d_update")
+    @register_fake("_C::causal_conv1d_update")
     def causal_conv1d_update_fake(
             x: torch.Tensor, conv_state: torch.Tensor, weight: torch.Tensor,
             bias_: Optional[torch.Tensor], silu_activation: bool,
@@ -524,7 +536,7 @@ try:
             conv_state_indices: Optional[torch.Tensor]) -> torch.Tensor:
         return torch.empty_like(x)
 
-    @torch.library.register_fake("_C::selective_scan_fwd")
+    @register_fake("_C::selective_scan_fwd")
     def selective_scan_fwd_fake(u: torch.Tensor, delta: torch.Tensor,
                                 A: torch.Tensor, B: torch.Tensor,
                                 C: torch.Tensor, D_: Optional[torch.Tensor],
@@ -947,7 +959,7 @@ def topk_softmax(topk_weights: torch.Tensor, topk_ids: torch.Tensor,
 
 
 if supports_moe_ops and hasattr(torch.ops._moe_C, "marlin_gemm_moe"):
-    @torch.library.register_fake("_moe_C::marlin_gemm_moe")
+    @register_fake("_moe_C::marlin_gemm_moe")
     def marlin_gemm_moe_fake(a: torch.Tensor, b_q_weights: torch.Tensor,
                              sorted_ids: torch.Tensor,
                              topk_weights: torch.Tensor,


### PR DESCRIPTION
Use `impl_abstract` if `register_fake` is unavailable (older torch versions)