### PR TITLE
CPU: add support for AWQ quants (slow)

### DIFF
--- a/=3.26
+++ b/=3.26
@@ -1,0 +1,31 @@
+Collecting cmake
+  Using cached cmake-3.31.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.5 kB)
+Collecting wheel
+  Using cached wheel-0.45.1-py3-none-any.whl.metadata (2.3 kB)
+Collecting packaging
+  Using cached packaging-24.2-py3-none-any.whl.metadata (3.2 kB)
+Collecting ninja
+  Using cached ninja-1.11.1.3-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.whl.metadata (5.3 kB)
+Collecting setuptools-scm>=8
+  Downloading setuptools_scm-8.2.0-py3-none-any.whl.metadata (6.8 kB)
+Collecting numpy
+  Downloading numpy-2.2.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (62 kB)
+Collecting setuptools>=61 (from setuptools-scm>=8)
+  Using cached setuptools-75.8.0-py3-none-any.whl.metadata (6.7 kB)
+Collecting tomli>=1 (from setuptools-scm>=8)
+  Using cached tomli-2.2.1-py3-none-any.whl.metadata (10 kB)
+Using cached cmake-3.31.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (27.8 MB)
+Using cached wheel-0.45.1-py3-none-any.whl (72 kB)
+Using cached packaging-24.2-py3-none-any.whl (65 kB)
+Using cached ninja-1.11.1.3-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (422 kB)
+Downloading setuptools_scm-8.2.0-py3-none-any.whl (43 kB)
+Downloading numpy-2.2.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (16.4 MB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 16.4/16.4 MB 119.9 MB/s eta 0:00:00
+Using cached setuptools-75.8.0-py3-none-any.whl (1.2 MB)
+Using cached tomli-2.2.1-py3-none-any.whl (14 kB)
+Installing collected packages: wheel, tomli, setuptools, packaging, numpy, ninja, cmake, setuptools-scm
+  Attempting uninstall: setuptools
+    Found existing installation: setuptools 59.6.0
+    Uninstalling setuptools-59.6.0:
+      Successfully uninstalled setuptools-59.6.0
+Successfully installed cmake-3.31.4 ninja-1.11.1.3 numpy-2.2.3 packaging-24.2 setuptools-75.8.0 setuptools-scm-8.2.0 tomli-2.2.1 wheel-0.45.1

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -22,6 +22,7 @@ ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4:/usr/local/li
 
 RUN echo 'ulimit -c 0' >> ~/.bashrc
 
+RUN pip install intel_extension_for_pytorch==2.4.0
 
 WORKDIR /workspace
 
@@ -30,14 +31,6 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,src=requirements-build.txt,target=requirements-build.txt \
     pip install --upgrade pip && \
     pip install -r requirements-build.txt
-RUN --mount=type=cache,target=/root/.cache/pip \
-    --mount=type=bind,src=requirements-cpu.txt,target=requirements-cpu.txt \
-    --mount=type=bind,src=requirements-common.txt,target=requirements-common.txt \
-    pip install --upgrade pip && \
-    pip install -r requirements-cpu.txt
-
-RUN pip install https://intel-extension-for-pytorch.s3.amazonaws.com/ipex_dev/cpu/intel_extension_for_pytorch-2.4.0%2Bgitfbaa4bc-cp310-cp310-linux_x86_64.whl
-
 
 # install oneDNN
 RUN git clone -b rls-v3.5 https://github.com/oneapi-src/oneDNN.git

--- a/aphrodite/modeling/layers/linear.py
+++ b/aphrodite/modeling/layers/linear.py
@@ -39,6 +39,7 @@ WEIGHT_LOADER_V2_SUPPORTED = [
     "ModelOptFp8LinearMethod",
     "QQQLinearMethod",
     "TPUInt8LinearMethod",
+    "IPEXAWQLinearMethod",
 ]
 
 

--- a/aphrodite/quantization/__init__.py
+++ b/aphrodite/quantization/__init__.py
@@ -18,6 +18,7 @@ from aphrodite.quantization.gptq import GPTQConfig
 from aphrodite.quantization.gptq_marlin import GPTQMarlinConfig
 from aphrodite.quantization.gptq_marlin_24 import GPTQMarlin24Config
 from aphrodite.quantization.hqq_marlin import HQQMarlinConfig
+from aphrodite.quantization.ipex_quant import IPEXConfig
 from aphrodite.quantization.marlin import MarlinConfig
 from aphrodite.quantization.modelopt import ModelOptFp8Config
 from aphrodite.quantization.neuron_quant import NeuronQuantConfig
@@ -62,6 +63,7 @@ QUANTIZATION_METHODS = {
     "fp7": QuantLLMFPConfig,
     "neuron_quant": NeuronQuantConfig,
     "vptq": VPTQConfig,
+    "ipex": IPEXConfig,
 }
 
 

--- a/aphrodite/quantization/awq_marlin.py
+++ b/aphrodite/quantization/awq_marlin.py
@@ -12,6 +12,7 @@ from aphrodite.modeling.layers.linear import (LinearBase, LinearMethodBase,
 from aphrodite.modeling.layers.vocab_parallel_embedding import ParallelLMHead
 from aphrodite.modeling.parameter import (GroupQuantScaleParameter,
                                           PackedAphroditeParameter)
+from aphrodite.platforms import current_platform
 from aphrodite.quantization.base_config import (QuantizationConfig,
                                                 QuantizeMethodBase)
 from aphrodite.quantization.utils import replace_parameter
@@ -120,6 +121,9 @@ class AWQMarlinConfig(QuantizationConfig):
         num_bits = quant_config.get("bits", None)
         group_size = quant_config.get("group_size", None)
         has_zp = quant_config.get("zero_point", None)
+
+        if not current_platform.is_cuda():
+            return False
 
         if quant_method != "awq":
             return False

--- a/aphrodite/quantization/ipex_quant.py
+++ b/aphrodite/quantization/ipex_quant.py
@@ -1,0 +1,165 @@
+from typing import Any, Dict, List, Optional
+
+import torch
+
+from aphrodite.modeling.layers.linear import LinearBase, LinearMethodBase
+from aphrodite.platforms import current_platform
+from aphrodite.quantization.awq import AWQLinearMethod
+from aphrodite.quantization.base_config import QuantizationConfig
+
+
+class IPEXConfig(QuantizationConfig):
+    """INT8 quantization config class using IPEX for the CPU backend,
+    including AWQ.
+    """
+
+    IPEX_QUANT_METHOD_MAP = {
+        "awq": 1,
+        "gptq": 2,
+    }
+
+    def __init__(
+        self,
+        method: str,
+        weight_bits: int,
+        group_size: int,
+    ) -> None:
+        self.method = method
+        self.weight_bits = weight_bits
+        self.group_size = group_size
+        self.pack_factor = 32 // self.weight_bits
+
+        if self.weight_bits not in [4]:
+            raise ValueError(f"IPEX quantization supports weight bits [4], "
+                             f"but got {self.weight_bits}.")
+
+        if self.method == "awq":
+            self.quant_method = IPEXAWQLinearMethod
+        else:
+            raise ValueError(f"IPEX quantization supports [awq], "
+                             f"but got {self.method}.")
+
+    def __repr__(self) -> str:
+        return (f"IPEXConfig(method={self.method}"
+                f"weight_bits={self.weight_bits}, "
+                f"group_size={self.group_size}")
+
+    def get_ipex_quant_method_id(self) -> int:
+        return IPEXConfig.IPEX_QUANT_METHOD_MAP[self.method]
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "ipex"
+
+    @classmethod
+    def get_supported_act_dtypes(cls) -> List[torch.dtype]:
+        return [torch.bfloat16, torch.float16]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return -1
+
+    @staticmethod
+    def get_config_filenames() -> List[str]:
+        return [
+            "quant_config.json",
+            "quantize_config.json",
+        ]
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "IPEXConfig":
+        method = cls.get_from_keys(config, ["quant_method"]).lower()
+        weight_bits = cls.get_from_keys(config, ["w_bit", "bits"])
+        group_size = cls.get_from_keys(config, ["q_group_size", "group_size"])
+        return cls(method, weight_bits, group_size)
+
+    @classmethod
+    def override_quantization_method(cls, hf_quant_cfg,
+                                     user_quant) -> Optional[str]:
+        if not current_platform.is_cpu():
+            return None
+
+        quant_method = hf_quant_cfg.get("quant_method", "").lower()
+
+        if quant_method in ["awq"]:
+            return cls.get_name()
+
+        return None
+
+    def get_quant_method(self, layer: torch.nn.Module,
+                         prefix: str) -> Optional["LinearMethodBase"]:
+        if isinstance(layer, LinearBase):
+            return self.quant_method(self)
+        return None
+
+    def get_scaled_act_names(self) -> List[str]:
+        if self.method == "awq":
+            return ["gelu", "gelu_fast", "gelu_new", "gelu_pytorch_tanh"]
+        else:
+            return []
+
+
+class IPEXAWQLinearMethod(AWQLinearMethod):
+    """AWQ linear method using IPEX for the CPU backend.
+    """
+
+    def __init__(self, quant_config: IPEXConfig):
+        self.quant_config = quant_config  # type: ignore
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        super().process_weights_after_loading(layer=layer)
+
+        bias = layer.bias if not layer.skip_bias_add else None
+
+        try:
+            import intel_extension_for_pytorch as ipex
+            if ipex.__version__ != "2.4.0":
+                raise ImportError("intel_extension_for_pytorch version is "
+                                  "wrong. Please install "
+                                  "intel_extension_for_pytorch==2.4.0.")
+        except ImportError as err:
+            raise ImportError(
+                "Please install "
+                "intel_extension_for_pytorch==2.4.0 via "
+                "`pip install intel_extension_for_pytorch==2.4.0`"
+                " to use IPEX-AWQ linear method.") from err
+
+        # Using the compute dtype (lowp_mode) as INT8 to leverage instructions
+        # with better performance.
+        lowp_mode = ipex.quantization.WoqLowpMode.INT8
+        # The weight will be de-packed from INT4 to INT8.
+        weight_dtype = ipex.quantization.WoqWeightDtype.INT4
+        # The float activation will be quantized (dynamic, per-token) to INT8.
+        act_quant_mode = ipex.quantization.WoqActQuantMode.PER_BATCH
+
+        qconfig = ipex.quantization.get_weight_only_quant_qconfig_mapping(
+            weight_dtype=weight_dtype,
+            lowp_mode=lowp_mode,
+            act_quant_mode=act_quant_mode,
+            group_size=self.quant_config.group_size,
+        )
+
+        layer.ipex_output_size = layer.qweight.size(
+            1) * self.quant_config.pack_factor
+        layer.ipex_qlinear = ipex.nn.modules.weight_only_quantization.\
+            WeightOnlyQuantizedLinear.from_weight(
+                layer.qweight,
+                layer.scales,
+                layer.qzeros,
+                layer.qweight.size(0),
+                layer.ipex_output_size,
+                qconfig=qconfig,
+                bias=bias,
+                group_size=self.quant_config.group_size,
+                quant_method=
+                    self.quant_config.get_ipex_quant_method_id() # type: ignore
+            )
+
+    def apply(self,
+              layer: torch.nn.Module,
+              x: torch.Tensor,
+              bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+        reshaped_x = x.reshape(-1, x.shape[-1])
+        out = layer.ipex_qlinear(reshaped_x)
+
+        return out.reshape(x.shape[:-1] + (layer.ipex_output_size, ))

--- a/aphrodite/worker/cpu_worker.py
+++ b/aphrodite/worker/cpu_worker.py
@@ -188,7 +188,8 @@ class CPUWorker(LoraNotSupportedWorkerBase, LocalOrDistributedWorkerBase):
     def init_device(self) -> None:
         if self.local_omp_cpuid != "all":
             ret = torch.ops._C_utils.init_cpu_threads_env(self.local_omp_cpuid)
-            logger.info(ret)
+            if ret:
+                logger.info(ret)
 
         self.init_distributed_environment()
         # Set random seed.


### PR DESCRIPTION
Very slow for large models. 8B AWQ takes about 5000 seconds to process 4 input tokens and 128 output tokens, end-to-end.

Tested on a CPU with AVX2. AVX512 is expected to perform much better.