### PR TITLE
`torch.compile`: integrate aphrodite with torch.compile

### DIFF
--- a/aphrodite/common/envs.py
+++ b/aphrodite/common/envs.py
@@ -65,6 +65,7 @@ if TYPE_CHECKING:
     APHRODITE_FORCE_P2P: bool = False
     APHRODITE_TEST_ENABLE_ARTIFICIAL_PREEMPT: bool = False
     APHRODITE_REQUEST_LEVEL_METRICS: bool = False
+    APHRODITE_TORCH_COMPILE_LEVEL: int = 0
 
 
 def get_default_cache_root():
@@ -199,18 +200,12 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     lambda: (os.environ.get(
         "APHRODITE_USE_TRITON_FLASH_ATTN", "True").lower() in ("true", "1")),
 
-    # Internal flag to enable Dynamo graph capture
-    "APHRODITE_TEST_DYNAMO_GRAPH_CAPTURE":
-    lambda: int(os.environ.get("APHRODITE_TEST_DYNAMO_GRAPH_CAPTURE", "0")),
-    "APHRODITE_DYNAMO_USE_CUSTOM_DISPATCHER":
-    lambda:
-    (os.environ.get("APHRODITE_DYNAMO_USE_CUSTOM_DISPATCHER", "True").lower() in
-     ("true", "1")),
-
     # Internal flag to enable Dynamo fullgraph capture
     "APHRODITE_TEST_DYNAMO_FULLGRAPH_CAPTURE":
     lambda: bool(
         os.environ.get("APHRODITE_TEST_DYNAMO_FULLGRAPH_CAPTURE", "1") != "0"),
+    "APHRODITE_TORCH_COMPILE_LEVEL":
+    lambda: int(os.environ.get("APHRODITE_TORCH_COMPILE_LEVEL", "0")),
 
     # local rank of the process in the distributed setting, used to determine
     # the GPU device id

--- a/aphrodite/common/sequence.py
+++ b/aphrodite/common/sequence.py
@@ -1137,10 +1137,9 @@ class EmbeddingSequenceGroupOutput(
         return self.embeddings == other.embeddings
 
 
-class IntermediateTensors(
-        msgspec.Struct,
-        omit_defaults=True,  # type: ignore[call-arg]
-        array_like=True):  # type: ignore[call-arg]
+# cannot use msgspec.Struct here because Dynamo does not support it
+@dataclass
+class IntermediateTensors:
     """For all pipeline stages except the last, we need to return the hidden
     states and residuals to be sent to the next stage. This data structure
     contains the hidden states and residuals for a request.

--- a/aphrodite/compilation/backends.py
+++ b/aphrodite/compilation/backends.py
@@ -1,7 +1,13 @@
+import copy
 import operator
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.fx as fx
+from loguru import logger
+
+from .compile_context import get_compile_context
+from .levels import CompilationLevel
 
 
 def fix_functionalization(graph: fx.Graph):
@@ -143,11 +149,113 @@ def fix_functionalization(graph: fx.Graph):
     #     print(graph.python_code(root_module="self", verbose=True).src, file=f)
 
 
-def aphrodite_backend(graph, example_inputs):
+def wrap_inductor(graph, example_inputs, additional_inductor_config):
     from torch._inductor import config
-
     current_config = config.shallow_copy_dict()
     from torch._inductor.compile_fx import compile_fx
 
-    current_config["post_grad_custom_post_pass"] = fix_functionalization
+    if additional_inductor_config is not None:
+        current_config.update(additional_inductor_config)
+    if current_config['post_grad_custom_post_pass'] is not None:
+        logger.warning(
+            "post_grad_custom_post_pass is already set in the config. "
+            "Overwriting it with the fix_functionalization")
+    current_config['post_grad_custom_post_pass'] = fix_functionalization
     return compile_fx(graph, example_inputs, config_patches=current_config)
+
+
+def aphrodite_backend(
+        graph,
+        example_inputs,
+        additional_inductor_config: Optional[Dict] = None) -> Callable:
+
+    context = get_compile_context()
+    context = copy.deepcopy(context) if context is not None else []
+    sizes_to_specialize: List[int] = context
+
+    # flags for all the seen shapes, whether we need to specialize
+    runtime_shapes_to_compile_flags: Dict[Tuple[int, ...], bool] = {}
+
+    # if we need to specialize, the compiled graph for that shape
+    runtime_shapes_to_compiled_graph: Dict[Tuple[int, ...], Callable] = {}
+
+    # this is the first compilation, we will compile a graph with
+    # dynamic shape, as the caller will mark first dimension as dynamic
+    logger.info("Compiling a graph for general shapes")
+    graph_for_symbolic_shape = wrap_inductor(graph, example_inputs,
+                                             additional_inductor_config)
+
+    # TODO: Dynamo does not pass all dynamic shapes.
+    # Need to investigate why. It works now because all the dynamic
+    # shapes have the same value, and either of them can be used.
+    sym_shape_indices = [
+        i for i, x in enumerate(example_inputs) if isinstance(x, torch.SymInt)
+    ]
+
+    first_run = True
+
+    # this is the function we return to Dynamo to run finally
+    def compiled_graph_wrapper(*args):
+
+        runtime_shapes: Tuple[int,
+                              ...] = tuple(args[i] for i in sym_shape_indices)
+
+        nonlocal first_run
+        nonlocal runtime_shapes_to_compile_flags
+        nonlocal runtime_shapes_to_compiled_graph
+
+        if first_run:
+            # the first compilation is for profiling, we directly run it
+            first_run = False
+            return graph_for_symbolic_shape(*args)
+
+        if runtime_shapes not in runtime_shapes_to_compile_flags:
+            # we haven't seen this shape before
+            # query if we need to specialize for this shape
+            # we only specialize for the first dimension.
+            # TODO: investigate if any model needs to specialize
+            # beyond the first dimension
+            runtime_shapes_to_compile_flags[runtime_shapes] = runtime_shapes[
+                0] in sizes_to_specialize
+
+        if not runtime_shapes_to_compile_flags[runtime_shapes]:
+            # we don't need to specialize for this shape
+            return graph_for_symbolic_shape(*args)
+
+        if runtime_shapes not in runtime_shapes_to_compiled_graph:
+            # we need to specialize for this shape, and we haven't compiled
+            # compile the graph for this shape
+            logger.info(f"Compiling a graph for shapes {runtime_shapes}")
+            runtime_shapes_to_compiled_graph[runtime_shapes] = wrap_inductor(
+                graph, args, additional_inductor_config)
+
+        return runtime_shapes_to_compiled_graph[runtime_shapes](*args)
+
+    return compiled_graph_wrapper
+
+
+def select_default_backend(level: int) -> Union[str, Callable]:
+    if level in [CompilationLevel.DYNAMO_AS_IS, CompilationLevel.DYNAMO_ONCE]:
+        backend = "eager"
+        return backend
+    assert level in [
+        CompilationLevel.INDUCTOR, CompilationLevel.INDUCTOR_MAX_AUTOTUNE
+    ], f"Invalid level {level}"
+
+    from aphrodite.compilation.backends import aphrodite_backend
+    from aphrodite.plugins import get_inductor_additional_configs
+    additional_configs = get_inductor_additional_configs()
+
+    if level == CompilationLevel.INDUCTOR_MAX_AUTOTUNE:
+        if "max_autotune" in additional_configs and not additional_configs[
+                "max_autotune"]:
+            logger.warning(
+                "max_autotune is disabled, but is overridden by level "
+                f"{CompilationLevel.INDUCTOR_MAX_AUTOTUNE}")
+        additional_configs['max_autotune'] = True
+
+    from functools import partial
+    backend = partial(aphrodite_backend,
+                      additional_inductor_config=additional_configs)
+
+    return backend

--- a/aphrodite/compilation/compile_context.py
+++ b/aphrodite/compilation/compile_context.py
@@ -1,0 +1,23 @@
+from contextlib import contextmanager
+from typing import Any
+
+_compile_context: Any = None
+
+
+def get_compile_context() -> Any:
+    """Get the current compile context."""
+    return _compile_context
+
+
+@contextmanager
+def set_compile_context(context: Any):
+    """A context manager that stores the current compile context,
+    usually it is a list of sizes to specialize.
+    """
+    global _compile_context
+    prev_context = _compile_context
+    _compile_context = context
+    try:
+        yield
+    finally:
+        _compile_context = prev_context

--- a/aphrodite/compilation/decorators.py
+++ b/aphrodite/compilation/decorators.py
@@ -1,0 +1,86 @@
+from typing import List, Optional, Union
+
+import torch
+
+import aphrodite.common.envs as envs
+from aphrodite.attention import AttentionMetadata
+from aphrodite.common.sequence import IntermediateTensors
+from aphrodite.common.utils import supports_dynamo
+from aphrodite.compilation.levels import CompilationLevel
+from aphrodite.compilation.wrapper import (
+    TorchCompileWrapperWithCustomDispatcher)
+
+
+def support_compile_llama_style(cls: type):
+    """
+    A decorator to add support for compiling the forward method of a class.
+    If a module's **forward signature** is compatible with llama, this 
+    decorator can be used to enable the compilation of the forward method.
+    """
+
+    # for CompilationLevel.DYNAMO_AS_IS , the upper level model runner
+    # will handle the compilation, so we don't need to do anything here.
+    if envs.APHRODITE_TORCH_COMPILE_LEVEL in [
+            CompilationLevel.NO_COMPILATION, CompilationLevel.DYNAMO_AS_IS
+    ] or not supports_dynamo():
+        return cls
+
+    # take care of method resolution order
+    # make sure super().__init__ is called on the base class
+    #  other than TorchCompileWrapperWithCustomDispatcher
+    cls.__bases__ = cls.__bases__ + (TorchCompileWrapperWithCustomDispatcher, )
+
+    old_init = cls.__init__
+
+    def __init__(self, *args, **kwargs):
+        old_init(self, *args, **kwargs)
+        TorchCompileWrapperWithCustomDispatcher.__init__(self)
+
+    cls.__init__ = __init__
+
+    def __call__(
+        self,
+        input_ids: Optional[torch.Tensor],
+        positions: torch.Tensor,
+        kv_caches: List[torch.Tensor],
+        attn_metadata: AttentionMetadata,
+        intermediate_tensors: Optional[IntermediateTensors],
+        inputs_embeds: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, IntermediateTensors]:
+        # torch.compiler.is_compiling() means we are inside the compilation
+        # e.g. TPU has the compilation logic in model runner, so we don't
+        # need to compile the model inside.
+        if torch.compiler.is_compiling():
+            return self.forward(input_ids, positions, kv_caches, attn_metadata,
+                                intermediate_tensors, inputs_embeds)
+
+        # the first compilation needs to have dynamic shapes marked
+        if len(self.compiled_codes) < 1:
+            if input_ids is not None:
+                torch._dynamo.mark_dynamic(input_ids, 0)
+            torch._dynamo.mark_dynamic(positions, 0)
+            if inputs_embeds is not None:
+                torch._dynamo.mark_dynamic(inputs_embeds, 0)
+            if intermediate_tensors is not None:
+                for tensors in intermediate_tensors.tensors.values():
+                    torch._dynamo.mark_dynamic(tensors, 0)
+
+        # if we don't use custom dispatcher, we can directly call the
+        # compiled function and let torch.compile handle the dispatching,
+        # with the overhead of guard evaluation and recompilation.
+        if len(self.compiled_codes) < 1 or not self.use_custom_dispatcher:
+            return self.compiled_callable(input_ids, positions, kv_caches,
+                                          attn_metadata, intermediate_tensors,
+                                          inputs_embeds)
+
+        # usually, capturing the model once is enough, and then we can
+        # dispatch to the compiled code directly, without going through
+        # the Dynamo guard mechanism.
+        with self.dispatch_to_code(0):
+            model_output = self.forward(input_ids, positions, kv_caches,
+                                        attn_metadata, intermediate_tensors,
+                                        inputs_embeds)
+            return model_output
+
+    cls.__call__ = __call__
+    return cls

--- a/aphrodite/compilation/levels.py
+++ b/aphrodite/compilation/levels.py
@@ -1,0 +1,9 @@
+# constants for the levels of the compilation process
+
+
+class CompilationLevel:
+    NO_COMPILATION = 0
+    DYNAMO_AS_IS = 1
+    DYNAMO_ONCE = 2
+    INDUCTOR = 3
+    INDUCTOR_MAX_AUTOTUNE = 4

--- a/aphrodite/modeling/_custom_op.py
+++ b/aphrodite/modeling/_custom_op.py
@@ -1,6 +1,8 @@
 import torch.nn as nn
 
+import aphrodite.common.envs as envs
 from aphrodite.common.utils import is_cpu, is_hip, is_triton, is_xpu
+from aphrodite.compilation.levels import CompilationLevel
 from aphrodite.platforms import current_platform
 
 
@@ -53,6 +55,8 @@ class CustomOp(nn.Module):
     def dispatch_forward(self):
         # NOTE: Here we assume that Aphrodite was built for only one
         # specific backend. Currently, we do not support dynamic dispatching.
+        if envs.APHRODITE_TORCH_COMPILE_LEVEL >= CompilationLevel.INDUCTOR:
+            return self.forward_native
         if is_hip():
             return self.forward_hip
         elif is_cpu():

--- a/aphrodite/modeling/models/gemma2.py
+++ b/aphrodite/modeling/models/gemma2.py
@@ -24,6 +24,7 @@ from transformers import Gemma2Config
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig, LoRAConfig
 from aphrodite.common.sequence import IntermediateTensors
+from aphrodite.compilation.decorators import support_compile_llama_style
 from aphrodite.distributed import (get_pp_group,
                                    get_tensor_model_parallel_world_size)
 from aphrodite.modeling.layers.activation import GeluAndMul
@@ -237,6 +238,7 @@ class Gemma2DecoderLayer(nn.Module):
         return hidden_states, residual
 
 
+@support_compile_llama_style
 class Gemma2Model(nn.Module):
 
     def __init__(

--- a/aphrodite/modeling/models/llama.py
+++ b/aphrodite/modeling/models/llama.py
@@ -31,6 +31,7 @@ from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig, LoRAConfig
 from aphrodite.common.sequence import IntermediateTensors
 from aphrodite.common.utils import is_hip
+from aphrodite.compilation.decorators import support_compile_llama_style
 from aphrodite.distributed import (get_current_tp_rank_partition_size,
                                    get_pp_group,
                                    get_tensor_model_parallel_rank,
@@ -264,6 +265,7 @@ class LlamaDecoderLayer(nn.Module):
         return hidden_states, residual
 
 
+@support_compile_llama_style
 class LlamaModel(nn.Module):
 
     def __init__(

--- a/aphrodite/modeling/models/llava.py
+++ b/aphrodite/modeling/models/llava.py
@@ -366,6 +366,8 @@ class LlavaForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP):
             input_ids = None
             inputs_embeds = None
         else:
+            # always pass the input via `inputs_embeds`
+            # to make sure the computation graph is consistent
             image_input = self._parse_and_validate_image_input(**kwargs)
 
             if image_input is not None:
@@ -376,10 +378,10 @@ class LlavaForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP):
                 inputs_embeds = merge_multimodal_embeddings(
                     input_ids, inputs_embeds, vision_embeddings,
                     self.config.image_token_index)
-
-                input_ids = None
             else:
-                inputs_embeds = None
+                inputs_embeds = self.language_model.model.get_input_embeddings(
+                    input_ids)
+            input_ids = None
 
         hidden_states = self.language_model.model(input_ids,
                                                   positions,

--- a/aphrodite/modeling/models/qwen2.py
+++ b/aphrodite/modeling/models/qwen2.py
@@ -31,6 +31,7 @@ from transformers import Qwen2Config
 from aphrodite.attention import Attention, AttentionMetadata
 from aphrodite.common.config import CacheConfig, LoRAConfig
 from aphrodite.common.sequence import IntermediateTensors
+from aphrodite.compilation.decorators import support_compile_llama_style
 from aphrodite.distributed import (get_current_tp_rank_partition_size,
                                    get_pp_group,
                                    get_tensor_model_parallel_rank,
@@ -221,6 +222,7 @@ class Qwen2DecoderLayer(nn.Module):
         return hidden_states, residual
 
 
+@support_compile_llama_style
 class Qwen2Model(nn.Module):
 
     def __init__(

--- a/aphrodite/platforms/tpu.py
+++ b/aphrodite/platforms/tpu.py
@@ -1,6 +1,21 @@
+import os
+
 import torch
 
+import aphrodite.common.envs as envs
+from aphrodite.compilation.levels import CompilationLevel
+from aphrodite.plugins import set_torch_compile_backend
+
 from .interface import Platform, PlatformEnum
+
+if "APHRODITE_TORCH_COMPILE_LEVEL" not in os.environ:
+    os.environ["APHRODITE_TORCH_COMPILE_LEVEL"] = str(
+        CompilationLevel.DYNAMO_ONCE)
+
+assert envs.APHRODITE_TORCH_COMPILE_LEVEL < CompilationLevel.INDUCTOR, \
+    "TPU does not support Inductor."
+
+set_torch_compile_backend("openxla")
 
 
 class TpuPlatform(Platform):

--- a/aphrodite/plugins/__init__.py
+++ b/aphrodite/plugins/__init__.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Union
+from typing import Callable, Dict, Optional, Union
 
 from loguru import logger
 
@@ -40,3 +40,15 @@ def set_torch_compile_backend(backend: Union[Callable, str]):
 
 def get_torch_compile_backend() -> Optional[Union[Callable, str]]:
     return _torch_compile_backend
+
+
+_inductor_additional_configs: Dict = {}
+
+
+def set_inductor_additional_configs(configs: Dict):
+    global _inductor_additional_configs
+    _inductor_additional_configs = configs
+
+
+def get_inductor_additional_configs() -> Dict:
+    return _inductor_additional_configs

--- a/aphrodite/quantization/vptq.py
+++ b/aphrodite/quantization/vptq.py
@@ -352,7 +352,8 @@ class VPTQConfig(QuantizationConfig):
                 }
             elif linear_name == "gate_up_proj":
                 quant_config = {
-                    "gate_proj": self.get_config_for_key(base_name, "gate_proj"),
+                    "gate_proj": self.get_config_for_key(base_name,
+                                                         "gate_proj"),
                     "up_proj": self.get_config_for_key(base_name, "up_proj"),
                 }
             else:

--- a/aphrodite/worker/tpu_model_runner.py
+++ b/aphrodite/worker/tpu_model_runner.py
@@ -19,7 +19,7 @@ from aphrodite.common.sequence import (CompletionSequenceGroupOutput,
                                        IntermediateTensors, Logprob,
                                        SequenceGroupMetadata, SequenceOutput)
 from aphrodite.compilation.wrapper import (
-    TorchCompileWrapperWithCustomDispacther)
+    TorchCompileWrapperWithCustomDispatcher)
 from aphrodite.modeling.layers.sampler import SamplerOutput
 from aphrodite.modeling.model_loader import get_model
 from aphrodite.modeling.sampling_metadata import SamplingMetadata
@@ -668,7 +668,7 @@ class TPUModelRunner(ModelRunnerBase[ModelInputForTPU]):
                                                  model_input.seq_groups)
             return [sampler_output]
 
-class ModelWrapper(TorchCompileWrapperWithCustomDispacther):
+class ModelWrapper(TorchCompileWrapperWithCustomDispatcher):
 
     def __init__(self, model: nn.Module):
         self.model = model

--- a/tests/compile/test_wrapper.py
+++ b/tests/compile/test_wrapper.py
@@ -3,7 +3,7 @@ from typing import Optional
 import torch
 
 from aphrodite.compilation.wrapper import (
-    TorchCompileWrapperWithCustomDispacther)
+    TorchCompileWrapperWithCustomDispatcher)
 
 
 class MyMod(torch.nn.Module):
@@ -13,7 +13,7 @@ class MyMod(torch.nn.Module):
         return x * 2
 
 
-class MyWrapper(TorchCompileWrapperWithCustomDispacther):
+class MyWrapper(TorchCompileWrapperWithCustomDispatcher):
     def __init__(self, model):
         self.model = model
         compiled_callable = torch.compile(self.forward, backend="eager")


### PR DESCRIPTION
We now should have full control over the compilation process, instead of just entrusting all to `torch.compile`.

Currently, we have 5 levels. Use the `APHRODITE_TORCH_COMPILE_LEVEL` flag to trigger each:

- **`0` (`NO_COMPILATION`)**: No compilation; normal Aphrodite.
- **`1` (`DYNAMO_AS_IS`)**: The model is directly passed to `torch.compile`, with no extra control or tuning. The model runner handles compilation in this case, and not our custom decorator. The backend is `eager`.
- **`2` (`DYNAMO_ONCE`)**: Uses `TorchDynamo` with a custom dispatcher; the model is compiled once, and we then reuse the compiled code. This should avoid repeated guard checks and recompilation, and will likely have better perf than `1`.
- **`3` (`INDUCTOR`)**: Uses `TorchInductor` backend with some custom optimizations; this includes specialized fixes for ops like RoPE and LayerNorm for the `forward_native` method. We use graph optimizations and kernel fusions here, and will use the `aphrodite_backend` instead of `eager` backend, which supports shape specialization. Visible performance boost.
- **`4` (`INDUCTOR_MAX_AUTOTUNE`)**: Same as `TorchInductor` but with maximum auto-tuning enabled. This should perform extensive kernel autotuning to find optimal config, but at the cost of very long compilation times.