### PR TITLE
fix: use proper vocab size for logit_bias

### DIFF
--- a/aphrodite/endpoints/openai/logits_processors.py
+++ b/aphrodite/endpoints/openai/logits_processors.py
@@ -70,7 +70,7 @@ def get_logits_processors(
 
         # Check if token_id is within the vocab size
         for token_id, bias in clamped_logit_bias.items():
-            if token_id < 0 or token_id >= tokenizer.vocab_size:
+            if token_id < 0 or token_id >= len(tokenizer):
                 raise ValueError("token_id in logit_bias contains "
                                  "out-of-vocab token id")
 
@@ -80,6 +80,6 @@ def get_logits_processors(
     if allowed_token_ids is not None:
         logits_processors.append(
             _get_allowed_token_ids_logits_processor(
-                frozenset(allowed_token_ids), tokenizer.vocab_size))
+                frozenset(allowed_token_ids), len(tokenizer)))
 
     return logits_processors


### PR DESCRIPTION
tokenizer.vocab_size returns the size of the vocab excluding added tokens while len(tokenizer) returns the proper size of the vocab including the added tokens. As seen here: https://github.com/huggingface/transformers/blob/79254c9b61ac2e1a6e0f698c38b1654159095e2e/src/transformers/tokenization_utils_fast.py#L234-L239 https://github.com/huggingface/transformers/blob/79254c9b61ac2e1a6e0f698c38b1654159095e2e/src/transformers/tokenization_utils_fast.py#L275-L279

This prevents errors when using added tokens as logit bias, such as trying to bias eos_token_id on for example meta-llama/Llama-3.1-8B-Instruct

I am unsure if there are any other places where this should be changed, but looking at the use cases of vocab_size in the rest of the repo, they mostly seem to be derived from the model config, which *should* be the correct size.

I was going to add a test case for this, but zephyr that's used in the tests doesn't have any added tokens that aren't part of the tokenizers vocab, and I wasn't sure how to best go about adding a test case for this with a new model, so I leave that up to a later PR, in any case it can be tested by running meta-llama/Llama-3.2-1B-Instruct, and sending the following request
```
curl -X POST http://localhost:2242/v1/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "Llama-3.1-8B-Instruct",
    "prompt": "Hello, world,",
    "max_tokens": 5,
    "logit_bias": {
      "128009": -100
    }
  }'
```
Which before this PR will return a 400 error like so
```
{"object":"error","message":"token_id in logit_bias contains out-of-vocab token id","type":"BadRequestError","param":null,"code":400}
```
And now after will properly generate