### PR TITLE
API: add batched tokenizer endpoint

### DIFF
--- a/aphrodite/endpoints/openai/protocol.py
+++ b/aphrodite/endpoints/openai/protocol.py
@@ -1087,6 +1087,18 @@ class TokenizeChatRequest(OpenAIBaseModel):
         return data
 
 
+class BatchTokenizeRequest(OpenAIBaseModel):
+    model: str
+    inputs: List[str]
+    add_special_tokens: bool = Field(default=True)
+    max_tokens: Optional[int] = None
+    truncate_prompt_tokens: Optional[Annotated[int, Field(ge=1)]] = None
+
+
+class BatchTokenizeResponse(OpenAIBaseModel):
+    results: List[Dict[str, Union[int, List[int]]]]
+    
+
 TokenizeRequest = Union[TokenizeCompletionRequest, TokenizeChatRequest]
 
 


### PR DESCRIPTION
Input format:

```sh
curl -s -X POST \
     -H "Content-Type: application/json" \
     -d '{
       "model": "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8",
       "inputs": [
         "What is a man?",
         "A miserable little pile of secrets"
       ]
     }' http://localhost:2242/v1/batch/tokenize
```

Response format:

```json
{
  "results": [
    {
      "tokens": [
        128000,
        3923,
        374,
        264,
        893,
        30
      ],
      "count": 6
    },
    {
      "tokens": [
        128000,
        32,
        50739,
        2697,
        27402,
        315,
        24511
      ],
      "count": 7
    }
  ]
}
```

Benchmarked with 1000 requests, with a total of 102588 randomly generated characters, at a batch size of 100:

```
Single Tokenization:
Total time: 2.3760s
Requests: 1000 (successful: 1000)
Average request time: 1281.11ms
Throughput: 420.87 requests/sec
Token throughput: 28992.62 tokens/sec

Batch Tokenization:
Total time: 0.0526s
Batches: 10 of size 100 (successful: 10)
Average batch time: 45.22ms
Throughput: 190.12 batches/sec
Effective throughput: 19012.13 texts/sec
Token throughput: 1309688.59 tokens/sec

Speedup: 45.17x (batch vs. single)
```
