### PR TITLE
[V1] feat: support fp8 kv on ampere through flashinfer

### DIFF
--- a/aphrodite/platforms/cuda.py
+++ b/aphrodite/platforms/cuda.py
@@ -491,8 +491,12 @@ class CudaPlatformBase(Platform):
         fp8_attention = kv_cache_dtype.startswith("fp8")
         will_use_fa = (not envs.is_set("APHRODITE_ATTENTION_BACKEND")
                        ) or envs.APHRODITE_ATTENTION_BACKEND == "FLASH_ATTN_APHRODITE_V1"
+        will_use_fi = (envs.APHRODITE_ATTENTION_BACKEND
+                       in ("FLASHINFER_APHRODITE_V1", "FLASHINFER"))
         supported = False
         if cls.is_device_capability(100):
+            supported = True
+        elif will_use_fi:
             supported = True
         elif fp8_attention and will_use_fa:
             from aphrodite.attention.utils.fa_utils import (


### PR DESCRIPTION
Works with prefix caching and chunked prefill. Tested on A100:

Need flashinfer first:

```sh
pip install -U flashinfer-python
```

FI uses JIT compilation for its CUDA kernels, so the first request will take a few minutes to complete.

```sh
APHRODITE_ATTENTION_BACKEND="FLASHINFER" aphrodite run Qwen/Qwen3-0.6B \
    --kv-cache-dtype fp8
```