### PR TITLE
feat: add DeepConf sampling

### DIFF
--- a/aphrodite/endpoints/openai/protocol.py
+++ b/aphrodite/endpoints/openai/protocol.py
@@ -476,6 +476,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
     mirostat_mode: Optional[int] = 0
     mirostat_tau: Optional[float] = 0.0
     mirostat_eta: Optional[float] = 0.0
+    enable_deepconf: Optional[bool] = False
+    deepconf_window_size: Optional[int] = 2048
+    deepconf_threshold: Optional[float] = 17
     # --8<-- [end:chat-completion-sampling-params]
 
     # doc: begin-chat-completion-extra-params
@@ -774,6 +777,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
             mirostat_eta=self.mirostat_eta,
             banned_phrases_token_ids=banned_phrases_token_ids,
             extra_args=extra_args or None,
+            enable_deepconf=self.enable_deepconf,
+            deepconf_window_size=self.deepconf_window_size,
+            deepconf_threshold=self.deepconf_threshold,
         )
 
     def _get_guided_json_from_tool(
@@ -1101,6 +1107,9 @@ class CompletionRequest(OpenAIBaseModel):
     mirostat_mode: Optional[int] = 0
     mirostat_tau: Optional[float] = 0.0
     mirostat_eta: Optional[float] = 0.0
+    enable_deepconf: Optional[bool] = False
+    deepconf_window_size: Optional[int] = 2048
+    deepconf_threshold: Optional[float] = 17
     # doc: end-completion-sampling-params
 
     # doc: begin-completion-extra-params
@@ -1362,6 +1371,9 @@ class CompletionRequest(OpenAIBaseModel):
             mirostat_eta=self.mirostat_eta,
             banned_phrases_token_ids=banned_phrases_token_ids,
             extra_args=extra_args or None,
+            enable_deepconf=self.enable_deepconf,
+            deepconf_window_size=self.deepconf_window_size,
+            deepconf_threshold=self.deepconf_threshold,
             )
 
     @model_validator(mode="before")

--- a/aphrodite/v1/engine/logprobs.py
+++ b/aphrodite/v1/engine/logprobs.py
@@ -1,4 +1,5 @@
 import itertools
+from collections import deque
 from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Optional
@@ -26,6 +27,12 @@ class LogprobsProcessor:
     num_logprobs: Optional[int]
     num_prompt_logprobs: Optional[int]
 
+    conf_grouped: Optional[float]
+    conf_list: Optional[list[float]]
+    conf_group_list: Optional[deque[float]]
+    conf_group_size: Optional[int]
+    conf_threshold: Optional[float]
+
     @classmethod
     def from_new_request(
         cls,
@@ -35,6 +42,20 @@ class LogprobsProcessor:
         assert request.sampling_params is not None
         num_logprobs = request.sampling_params.logprobs
         num_prompt_logprobs = request.sampling_params.prompt_logprobs
+
+        if request.sampling_params.enable_deepconf:
+            conf_group_size = request.sampling_params.deepconf_window_size
+            conf_threshold = request.sampling_params.deepconf_threshold
+            conf_grouped = 0.0
+            conf_group_list = deque(maxlen=conf_group_size)
+            conf_list = []
+        else:
+            conf_group_size = -1
+            conf_threshold = None
+            conf_grouped = 0.0
+            conf_group_list = None
+            conf_list = None
+
         return cls(
             tokenizer=tokenizer,
             cumulative_logprob=(None if num_logprobs is None else 0.),
@@ -43,7 +64,22 @@ class LogprobsProcessor:
             prompt_logprobs=(None if num_prompt_logprobs is None else [None]),
             num_prompt_logprobs=num_prompt_logprobs,
             num_logprobs=num_logprobs,
+            conf_group_size=conf_group_size,
+            conf_grouped=conf_grouped,
+            conf_list=conf_list,
+            conf_threshold=conf_threshold,
+            conf_group_list=conf_group_list,
         )
+
+    def check_conf_stop(self) -> bool:
+        """Return True if the confidence window triggers early stopping."""
+        if self.conf_group_list is None or len(self.conf_group_list) == 0:
+            return False
+        # Require a full window; trigger when the moving average is below
+        # threshold.
+        return (len(self.conf_group_list) >= self.conf_group_size
+                and self.conf_grouped / len(self.conf_group_list) <
+                self.conf_threshold)
 
     def _update_sample_logprobs(self, logprobs_lists: LogprobsLists) -> None:
         """Update with sample logprobs from EngineCore.
@@ -82,6 +118,23 @@ class LogprobsProcessor:
                     rank,
                     self.num_logprobs,
                 ))
+
+            if self.conf_list is not None:
+                # logprobs[0] is the sampled token; use the remaining
+                # candidates
+                if len(logprobs) > 1:
+                    new_conf = -sum(logprobs[1:]) / len(logprobs[1:])
+                else:
+                    new_conf = 0.0
+                self.conf_list.append(new_conf)
+
+                if len(self.conf_group_list) < self.conf_group_size:
+                    self.conf_group_list.append(new_conf)
+                    self.conf_grouped += new_conf
+                else:
+                    self.conf_grouped -= self.conf_group_list.popleft()
+                    self.conf_group_list.append(new_conf)
+                    self.conf_grouped += new_conf
 
     def _update_prompt_logprobs(
         self,

--- a/aphrodite/v1/engine/output_processor.py
+++ b/aphrodite/v1/engine/output_processor.py
@@ -416,7 +416,7 @@ class OutputProcessor:
                 if req_state.logprobs_processor.check_conf_stop():
                     finish_reason = FinishReason.STOP
                     stop_reason = (
-                        f"<gconf<"
+                        f"<deepconf-"
                         f"{req_state.logprobs_processor.conf_threshold}>")
 
             # 4) Create and handle RequestOutput objects.

--- a/aphrodite/v1/engine/output_processor.py
+++ b/aphrodite/v1/engine/output_processor.py
@@ -413,6 +413,12 @@ class OutputProcessor:
                 req_state.logprobs_processor.update_from_output(
                     engine_core_output)
 
+                if req_state.logprobs_processor.check_conf_stop():
+                    finish_reason = FinishReason.STOP
+                    stop_reason = (
+                        f"<gconf<"
+                        f"{req_state.logprobs_processor.conf_threshold}>")
+
             # 4) Create and handle RequestOutput objects.
             if request_output := req_state.make_request_output(
                     new_token_ids, pooling_output, finish_reason, stop_reason,


### PR DESCRIPTION
This PR implements [DeepConf (Deep Think with Confidence)](https://arxiv.org/abs/2508.15260), a confidence-based early stopping mechanism that automatically halts text generation when the model's confidence drops below a threshold.

To test via the API (logprobs is needed):

```sh
curl -s -X POST http://localhost:2242/v1/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "NousResearch/Meta-Llama-3.1-8B-Instruct",
    "prompt": "Let me think about this carefully... um... what is the square root of 144? I need to... let me see... I'\''m not sure about this... maybe it'\''s...",
    "enable_deepconf": true,
    "logprobs": 0,
    "deepconf_window_size": 50,
    "deepconf_threshold": 10
  }' | jq .
```

Output:

<details>
  <summary>Click to expand</summary>

```json
{
  "id": "cmpl-72ab985bc1a7441c948ab07ea4a5e799",
  "object": "text_completion",
  "created": 1756123855,
  "model": "NousResearch/Meta-Llama-3.1-8B-Instruct",
  "choices": [
    {
      "index": 0,
      "text": " uh... 12! That's right! The square root of 144 is 12.\nBut what if it's a negative number? Do I just differentiate that and then again reverse it? So if I'm trying to solve another problem, something",
      "logprobs": {
        "text_offset": [
          0,
          3,
          6,
          7,
          9,
          10,
          15,
          17,
          23,
          24,
          28,
          35,
          40,
          43,
          44,
          47,
          50,
          51,
          53,
          55,
          58,
          63,
          66,
          69,
          71,
          73,
          82,
          89,
          90,
          93,
          95,
          100,
          114,
          119,
          123,
          128,
          134,
          142,
          145,
          146,
          149,
          152,
          154,
          156,
          163,
          166,
          172,
          180,
          188,
          189
        ],
        "token_logprobs": [
          -1.0326826572418213,
          -0.07341671735048294,
          -1.0715587139129639,
          -0.9896953105926514,
          -3.0837316513061523,
          -2.2240610122680664,
          -0.5109037756919861,
          -0.5604236125946045,
          -0.7761133313179016,
          -0.6418013572692871,
          -0.030950123444199562,
          -0.004184538498520851,
          -0.0012425805907696486,
          -0.0017688118387013674,
          -0.005166275426745415,
          -0.007158228196203709,
          -0.18158631026744843,
          -0.0004239375703036785,
          -2.784702777862549,
          -3.075881004333496,
          -2.4593448638916016,
          -1.9918367862701416,
          -2.8072731494903564,
          -0.6419885754585266,
          -2.0631117820739746,
          -0.2904081642627716,
          -0.3234063684940338,
          -0.17118950188159943,
          -2.8729846477508545,
          -0.5912193059921265,
          -2.100228786468506,
          -12.257498741149902,
          -3.6402034759521484,
          -2.711117744445801,
          -1.9479526281356812,
          -7.848573684692383,
          -9.157028198242188,
          -2.030367612838745,
          -0.5505211353302002,
          -4.454358100891113,
          -2.0961668491363525,
          -0.5875948071479797,
          -3.1302449703216553,
          -1.8771792650222778,
          -0.00410939147695899,
          -2.146735906600952,
          -8.207291603088379,
          -1.9649379253387451,
          -1.4308969974517822,
          -4.70171594619751
        ],
        "tokens": [
          " uh",
          "...",
          " ",
          "12",
          "!",
          " That",
          "'s",
          " right",
          "!",
          " The",
          " square",
          " root",
          " of",
          " ",
          "144",
          " is",
          " ",
          "12",
          ".\n",
          "But",
          " what",
          " if",
          " it",
          "'s",
          " a",
          " negative",
          " number",
          "?",
          " Do",
          " I",
          " just",
          " differentiate",
          " that",
          " and",
          " then",
          " again",
          " reverse",
          " it",
          "?",
          " So",
          " if",
          " I",
          "'m",
          " trying",
          " to",
          " solve",
          " another",
          " problem",
          ",",
          " something"
        ],
        "top_logprobs": [
          {
            " uh": -1.0326826572418213
          },
          {
            "...": -0.07341671735048294
          },
          {
            " ": -1.0715587139129639
          },
          {
            "12": -0.9896953105926514
          },
          {
            "!": -3.0837316513061523
          },
          {
            " That": -2.2240610122680664
          },
          {
            "'s": -0.5109037756919861
          },
          {
            " right": -0.5604236125946045
          },
          {
            "!": -0.7761133313179016
          },
          {
            " The": -0.6418013572692871
          },
          {
            " square": -0.030950123444199562
          },
          {
            " root": -0.004184538498520851
          },
          {
            " of": -0.0012425805907696486
          },
          {
            " ": -0.0017688118387013674
          },
          {
            "144": -0.005166275426745415
          },
          {
            " is": -0.007158228196203709
          },
          {
            " ": -0.18158631026744843
          },
          {
            "12": -0.0004239375703036785
          },
          {
            ".\n": -2.784702777862549
          },
          {
            "But": -3.075881004333496
          },
          {
            " what": -2.4593448638916016
          },
          {
            " if": -1.9918367862701416
          },
          {
            " it": -2.8072731494903564
          },
          {
            "'s": -0.6419885754585266
          },
          {
            " a": -2.0631117820739746
          },
          {
            " negative": -0.2904081642627716
          },
          {
            " number": -0.3234063684940338
          },
          {
            "?": -0.17118950188159943
          },
          {
            " Do": -2.8729846477508545
          },
          {
            " I": -0.5912193059921265
          },
          {
            " just": -2.100228786468506
          },
          {
            " differentiate": -12.257498741149902
          },
          {
            " that": -3.6402034759521484
          },
          {
            " and": -2.711117744445801
          },
          {
            " then": -1.9479526281356812
          },
          {
            " again": -7.848573684692383
          },
          {
            " reverse": -9.157028198242188
          },
          {
            " it": -2.030367612838745
          },
          {
            "?": -0.5505211353302002
          },
          {
            " So": -4.454358100891113
          },
          {
            " if": -2.0961668491363525
          },
          {
            " I": -0.5875948071479797
          },
          {
            "'m": -3.1302449703216553
          },
          {
            " trying": -1.8771792650222778
          },
          {
            " to": -0.00410939147695899
          },
          {
            " solve": -2.146735906600952
          },
          {
            " another": -8.207291603088379
          },
          {
            " problem": -1.9649379253387451
          },
          {
            ",": -1.4308969974517822
          },
          {
            " something": -4.70171594619751
          }
        ]
      },
      "finish_reason": "stop",
      "stop_reason": "<gconf<10.0>",
      "prompt_logprobs": null
    }
  ],
  "service_tier": null,
  "system_fingerprint": null,
  "usage": {
    "prompt_tokens": 37,
    "total_tokens": 87,
    "completion_tokens": 50,
    "prompt_tokens_details": null
  },
  "kv_transfer_params": null
}
```
</details>

The example uses only 1 logprob output, with a very low threshold and window size for demonstrative purposes. Normally, you would use higher values, e.g. a default of 2048 window size and 17 threshold (empirically validated via the DeepConf paper).