### PR TITLE
build: add option to disable flash attn compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -916,6 +916,11 @@ endif()
 if (APHRODITE_GPU_LANG STREQUAL "CUDA")
     include(cmake/external_project/flashmla.cmake)
 
-    # vllm-flash-attn should be last as it overwrites some CMake functions
-    include(cmake/external_project/vllm_flash_attn.cmake)
+    # Only build flash attention if not disabled
+    if (NOT DEFINED ENV{APHRODITE_DISABLE_FLASH_ATTN} OR NOT $ENV{APHRODITE_DISABLE_FLASH_ATTN})
+        # vllm-flash-attn should be last as it overwrites some CMake functions
+        include(cmake/external_project/vllm_flash_attn.cmake)
+    else()
+        message(STATUS "Flash attention compilation disabled by APHRODITE_DISABLE_FLASH_ATTN")
+    endif()
 endif()

--- a/aphrodite/common/envs.py
+++ b/aphrodite/common/envs.py
@@ -160,6 +160,7 @@ if TYPE_CHECKING:
     APHRODITE_REQUEST_LEVEL_METRICS: bool = False
     APHRODITE_USE_SAMPLING_KERNELS: bool = False
     APHRODITE_NO_DEPRECATION_WARNING: bool = False
+    APHRODITE_DISABLE_FLASH_ATTN: bool = False
     APHRODITE_DYNAMIC_ROPE_SCALING: bool = False
     APHRODITE_USE_FLASHINFER_MOE_MXFP4_MXFP8: bool = False
     APHRODITE_USE_FLASHINFER_MOE_MXFP4_BF16: bool = False
@@ -1158,6 +1159,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set, aphrodite will not show deprecation warnings
     "APHRODITE_NO_DEPRECATION_WARNING":
     lambda: bool(int(os.getenv("APHRODITE_NO_DEPRECATION_WARNING", "0"))),
+
+    # If set, aphrodite will disable compilation of flash attention kernels
+    "APHRODITE_DISABLE_FLASH_ATTN_COMPILE":
+    lambda: bool(int(os.getenv("APHRODITE_DISABLE_FLASH_ATTN_COMPILE", "0"))),
 
     # If set, aphrodite will use dynamic rope scaling.
     "APHRODITE_DYNAMIC_ROPE_SCALING":

--- a/setup.py
+++ b/setup.py
@@ -639,16 +639,21 @@ if not envs.APHRODITE_USE_PRECOMPILED:
         ext_modules.append(CMakeExtension(name="aphrodite._rocm_C"))
 
     if _is_cuda():
-        ext_modules.append(CMakeExtension(
-            name="aphrodite.aphrodite_flash_attn._vllm_fa2_C"))
-        # Build FA3/_flashmla when using precompiled artifacts or nvcc >= 12.3.
+        if not envs.APHRODITE_DISABLE_FLASH_ATTN_COMPILE:
+            ext_modules.append(CMakeExtension(
+                name="aphrodite.aphrodite_flash_attn._vllm_fa2_C"))
+            # Build FA3 when using precompiled artifacts or nvcc >= 12.3.
+            if envs.APHRODITE_USE_PRECOMPILED or \
+                    get_nvcc_cuda_version() >= Version("12.3"):
+                ext_modules.append(
+                    CMakeExtension(
+                        name="aphrodite.aphrodite_flash_attn._vllm_fa3_C"))
+
+        # Build flashmla when using precompiled artifacts or nvcc >= 12.3.
+        # Optional since this doesn't get built (produce an .so file) when
+        # not targeting a hopper system
         if envs.APHRODITE_USE_PRECOMPILED or \
                 get_nvcc_cuda_version() >= Version("12.3"):
-            ext_modules.append(
-                CMakeExtension(
-                    name="aphrodite.aphrodite_flash_attn._vllm_fa3_C"))
-            # Optional since this doesn't get built (produce an .so file) when
-            # not targeting a hopper system
             ext_modules.append(
                 CMakeExtension(name="aphrodite._flashmla_C", optional=True))
         ext_modules.append(CMakeExtension(name="aphrodite.cumem_allocator"))


### PR DESCRIPTION
Flash Attention kernels are very expensive to build, and they are rebuilt every time you make a small change to other unrelated kernels. This PR lets you skip that step by exporting the `APHRODITE_DISABLE_FLASH_ATTN=1` env var.