### PR TITLE
feat: enable pytorch symmetric memory for A100 GPUs

### DIFF
--- a/aphrodite/distributed/device_communicators/all_reduce_utils.py
+++ b/aphrodite/distributed/device_communicators/all_reduce_utils.py
@@ -39,6 +39,12 @@ CUSTOM_ALL_REDUCE_MAX_SIZES = {
 }
 
 SYMM_MEM_ALL_REDUCE_MAX_SIZES = {
+    "8.0": {
+        2: 1 * MiB,    # 1 MB
+        4: MiB // 2,   # 512 KB
+        6: 1 * MiB,    # 1 MB
+        8: 1 * MiB,    # 1 MB
+    },
     "9.0": {
         2: 64 * MiB,  # 64 MB
         4: 32 * MiB,  # 32 MB

--- a/aphrodite/distributed/device_communicators/symm_mem.py
+++ b/aphrodite/distributed/device_communicators/symm_mem.py
@@ -19,6 +19,7 @@ except ImportError:
 
 class SymmMemCommunicator:
     _WORLD_SIZES_MULTIMEM = {
+        "8.0": [2, 4, 6, 8],
         "9.0": [4, 6, 8],
         "10.0": [6, 8],
     }


### PR DESCRIPTION
It's a very minor speedup.

```sh
APHRODITE_ALLREDUCE_USE_SYMM_MEM=1
```