### PR TITLE
[build] fix: relax xformers dependency version

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -11,4 +11,4 @@ torchaudio==2.8.0
 # These must be updated alongside torch
 torchvision==0.23.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 # https://github.com/facebookresearch/xformers/releases/tag/v0.0.31
-xformers>=0.0.32.post2; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.7
+xformers>0.0.32.post2; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.7

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -11,4 +11,4 @@ torchaudio==2.8.0
 # These must be updated alongside torch
 torchvision==0.23.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 # https://github.com/facebookresearch/xformers/releases/tag/v0.0.31
-xformers>0.0.32.post2; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.7
+xformers>0.0.32.post2; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.8

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -11,4 +11,4 @@ torchaudio==2.8.0
 # These must be updated alongside torch
 torchvision==0.23.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 # https://github.com/facebookresearch/xformers/releases/tag/v0.0.31
-xformers>0.0.32.post2; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.8
+xformers>0.0.32.post2, <0.0.34; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.8

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -11,4 +11,4 @@ torchaudio==2.8.0
 # These must be updated alongside torch
 torchvision==0.23.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 # https://github.com/facebookresearch/xformers/releases/tag/v0.0.31
-xformers==0.0.33.dev1079; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.7
+xformers>=0.0.32.post2; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.7


### PR DESCRIPTION
Fixes #1535 

Looks like xformers regularly deletes their pre-releases, so we should just set the version to anything above `0.0.32.post2` to support pytorch 2.8 + cuda 12.8.